### PR TITLE
fix(workspaces): Use hard delete to allow re-cloning repos

### DIFF
--- a/src/socket/socket.handler.js
+++ b/src/socket/socket.handler.js
@@ -9,20 +9,20 @@ class SocketHandler {
   initialize(io) {
     // JWT authentication middleware
     io.use(socketAuthMiddleware);
-    
+
     // Connection handler
     io.on('connection', (socket) => {
       logger.info(`User ${socket.user.username} connected (${socket.id})`);
-      
+
       // Load workspaces on connection
       this.loadWorkspaces(socket);
-      
+
       // Register terminal handlers
       this.registerTerminalHandlers(socket);
-      
+
       // Register workspace event handlers
       this.registerWorkspaceHandlers(socket);
-      
+
       // Disconnect handler
       socket.on('disconnect', (reason) => {
         logger.info(`User ${socket.user.username} disconnected (${socket.id}): ${reason}`);
@@ -31,7 +31,7 @@ class SocketHandler {
       });
     });
   }
-  
+
   registerTerminalHandlers(socket) {
     // Create terminal session
     socket.on('create-terminal', async (data) => {
@@ -75,7 +75,7 @@ class SocketHandler {
         socket.emit('terminal-error', { error: error.message });
       }
     });
-    
+
     // Kill terminal session explicitly
     socket.on('kill-terminal', async (data) => {
       try {
@@ -107,33 +107,33 @@ class SocketHandler {
       try {
         logger.info('Received create-workspace request:', data);
         const { githubRepo, githubUrl } = data;
-        
+
         if (!githubRepo || !githubUrl) {
           logger.error('Missing required parameters for workspace creation');
-          return socket.emit('workspace-error', { 
-            error: 'Missing required parameters: githubRepo and githubUrl' 
+          return socket.emit('workspace-error', {
+            error: 'Missing required parameters: githubRepo and githubUrl'
           });
         }
 
         // Emit progress update
         logger.info('Emitting workspace-progress: creating');
-        socket.emit('workspace-progress', { 
+        socket.emit('workspace-progress', {
           status: 'creating',
           message: `Creating workspace for ${githubRepo}...`
         });
 
         const workspace = await workspaceService.createWorkspace(
-          githubRepo, 
+          githubRepo,
           githubUrl
         );
         logger.info('Workspace created successfully:', workspace.id);
 
         logger.info('Emitting workspace-created event');
         socket.emit('workspace-created', { workspace });
-        
+
         // Auto-trigger repository cloning
         logger.info('Emitting workspace-progress: cloning');
-        socket.emit('workspace-progress', { 
+        socket.emit('workspace-progress', {
           status: 'cloning',
           workspaceId: workspace.id,
           message: `Cloning repository ${githubRepo}...`
@@ -146,19 +146,19 @@ class SocketHandler {
           socket.emit('workspace-cloned', { workspace: clonedWorkspace });
         } catch (cloneError) {
           logger.error('Auto-clone failed:', cloneError);
-          socket.emit('workspace-error', { 
-            error: `Workspace created but clone failed: ${cloneError.message}` 
+          socket.emit('workspace-error', {
+            error: `Workspace created but clone failed: ${cloneError.message}`
           });
         }
-        
+
         // Reload workspaces list
         logger.info('Reloading workspaces list');
         await this.loadWorkspaces(socket);
-        
+
       } catch (error) {
         logger.error('Error creating workspace:', error);
-        socket.emit('workspace-error', { 
-          error: error.message || 'Failed to create workspace' 
+        socket.emit('workspace-error', {
+          error: error.message || 'Failed to create workspace'
         });
       }
     });
@@ -167,39 +167,39 @@ class SocketHandler {
     socket.on('clone-workspace', async (data) => {
       try {
         const { workspaceId } = data;
-        
+
         if (!workspaceId) {
-          return socket.emit('workspace-error', { 
-            error: 'Missing workspaceId parameter' 
+          return socket.emit('workspace-error', {
+            error: 'Missing workspaceId parameter'
           });
         }
 
         // Get workspace (no ownership check needed for single user)
         const workspace = await workspaceService.getWorkspace(workspaceId);
         if (!workspace) {
-          return socket.emit('workspace-error', { 
-            error: 'Workspace not found' 
+          return socket.emit('workspace-error', {
+            error: 'Workspace not found'
           });
         }
 
         // Emit progress update
-        socket.emit('workspace-progress', { 
+        socket.emit('workspace-progress', {
           status: 'cloning',
           workspaceId,
           message: `Cloning repository ${workspace.githubRepo}...`
         });
 
         const updatedWorkspace = await workspaceService.cloneRepository(workspaceId);
-        
+
         socket.emit('workspace-cloned', { workspace: updatedWorkspace });
-        
+
         // Reload workspaces list
         await this.loadWorkspaces(socket);
-        
+
       } catch (error) {
         logger.error('Error cloning workspace:', error);
-        socket.emit('workspace-error', { 
-          error: error.message || 'Failed to clone repository' 
+        socket.emit('workspace-error', {
+          error: error.message || 'Failed to clone repository'
         });
       }
     });
@@ -208,32 +208,36 @@ class SocketHandler {
     socket.on('delete-workspace', async (data) => {
       try {
         const { workspaceId, deleteFiles = false } = data;
-        
+
         if (!workspaceId) {
-          return socket.emit('workspace-error', { 
-            error: 'Missing workspaceId parameter' 
+          return socket.emit('workspace-error', {
+            error: 'Missing workspaceId parameter'
           });
         }
 
-        // Get workspace (no ownership check needed for single user)
+        // Get workspace to ensure it exists before proceeding
         const workspace = await workspaceService.getWorkspace(workspaceId);
         if (!workspace) {
-          return socket.emit('workspace-error', { 
-            error: 'Workspace not found' 
+          return socket.emit('workspace-error', {
+            error: 'Workspace not found'
           });
         }
 
+        // First, kill any active shell session for this workspace
+        shellService.killSession(workspaceId);
+
+        // Then, proceed with deleting the workspace record and files
         await workspaceService.deleteWorkspace(workspaceId, deleteFiles);
-        
+
         socket.emit('workspace-deleted', { workspaceId });
-        
-        // Reload workspaces list
+
+        // Reload workspaces list for the client
         await this.loadWorkspaces(socket);
-        
+
       } catch (error) {
         logger.error('Error deleting workspace:', error);
-        socket.emit('workspace-error', { 
-          error: error.message || 'Failed to delete workspace' 
+        socket.emit('workspace-error', {
+          error: error.message || 'Failed to delete workspace'
         });
       }
     });
@@ -242,39 +246,39 @@ class SocketHandler {
     socket.on('sync-workspace', async (data) => {
       try {
         const { workspaceId } = data;
-        
+
         if (!workspaceId) {
-          return socket.emit('workspace-error', { 
-            error: 'Missing workspaceId parameter' 
+          return socket.emit('workspace-error', {
+            error: 'Missing workspaceId parameter'
           });
         }
 
         // Get workspace (no ownership check needed for single user)
         const workspace = await workspaceService.getWorkspace(workspaceId);
         if (!workspace) {
-          return socket.emit('workspace-error', { 
-            error: 'Workspace not found' 
+          return socket.emit('workspace-error', {
+            error: 'Workspace not found'
           });
         }
 
         // Emit progress update
-        socket.emit('workspace-progress', { 
+        socket.emit('workspace-progress', {
           status: 'syncing',
           workspaceId,
           message: `Syncing workspace ${workspace.githubRepo}...`
         });
 
         const updatedWorkspace = await workspaceService.syncWithGitHub(workspaceId);
-        
+
         socket.emit('workspace-synced', { workspace: updatedWorkspace });
-        
+
         // Reload workspaces list
         await this.loadWorkspaces(socket);
-        
+
       } catch (error) {
         logger.error('Error syncing workspace:', error);
-        socket.emit('workspace-error', { 
-          error: error.message || 'Failed to sync workspace' 
+        socket.emit('workspace-error', {
+          error: error.message || 'Failed to sync workspace'
         });
       }
     });
@@ -283,11 +287,11 @@ class SocketHandler {
     socket.on('get-repositories', async (data) => {
       try {
         const { page = 1, per_page = 100, sort = 'updated', search = '' } = data || {};
-        
+
         const githubToken = await settingsService.getGithubToken();
         if (!githubToken) {
-          return socket.emit('repositories-error', { 
-            error: 'GitHub token not found. Please authorize GitHub access first.' 
+          return socket.emit('repositories-error', {
+            error: 'GitHub token not found. Please authorize GitHub access first.'
           });
         }
 
@@ -305,14 +309,14 @@ class SocketHandler {
         let repositories = result.repositories;
         if (search && search.trim()) {
           const searchTerm = search.toLowerCase().trim();
-          repositories = repositories.filter(repo => 
+          repositories = repositories.filter(repo =>
             repo.name.toLowerCase().includes(searchTerm) ||
             repo.full_name.toLowerCase().includes(searchTerm) ||
             (repo.description && repo.description.toLowerCase().includes(searchTerm))
           );
         }
 
-        socket.emit('repositories-list', { 
+        socket.emit('repositories-list', {
           repositories,
           pagination: {
             ...result.pagination,
@@ -320,11 +324,11 @@ class SocketHandler {
             search_applied: !!search
           }
         });
-        
+
       } catch (error) {
         logger.error('Error getting repositories:', error);
-        socket.emit('repositories-error', { 
-          error: error.message || 'Failed to load repositories' 
+        socket.emit('repositories-error', {
+          error: error.message || 'Failed to load repositories'
         });
       } finally {
         socket.emit('repositories-loading', { loading: false });


### PR DESCRIPTION
Switched from soft-deleting workspaces (`isActive=false`) to a hard delete (`prisma.delete()`).

This resolves the unique constraint error that occurred when attempting to clone a repository that had been previously deleted. Active shell sessions are now killed before the record is removed.