### PR TITLE
ci: Trigger workflow on push to main

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,6 +1,8 @@
-name: Run Tests on PR
+name: CI
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
Updates the CI workflow to also run on pushes to the `main` branch, in addition to pull requests.

This ensures tests are executed against the final merged code, providing continuous validation for the main integration branch. The workflow name is also updated to "CI" for better clarity.